### PR TITLE
Flipped Fractal Pepes

### DIFF
--- a/collections/flipped-fractal-pepes/meta.json
+++ b/collections/flipped-fractal-pepes/meta.json
@@ -1,0 +1,9 @@
+{
+    "description": "The Mirrored Collection of the first 10k PFP on Fractal Bitcoin, inscribed from Block 288 after the mainnet went live, pre-Block 21,000 inscription numbers 2-10,001",
+    "discord_link": "",
+    "icon": "https://",
+    "name": "Flipped Fractal Pepes",
+    "slug": "fractalpepes",
+    "twitter_link": "https://x.com/fractalpepes",
+    "website_link": "https://"
+}


### PR DESCRIPTION
The Mirrored Collection of the first 10k PFP on Fractal Bitcoin, inscribed from Block 288 after the mainnet went live, pre-Block 21,000 inscription numbers 2-10,001