### PR TITLE
Pixel Poo - twitter updated in meta

### DIFF
--- a/collections/pixel_poo/meta.json
+++ b/collections/pixel_poo/meta.json
@@ -4,6 +4,6 @@
   "icon": "https://i.ibb.co/8mvvRD3/15.png",
   "name": "PIXEL_POO",
   "slug": "pixel_poo", 
-  "twitter_link": "https://x.com/pixlpoo",
+  "twitter_link": "https://x.com/FractalShiddz",
   "website_link": ""
 }


### PR DESCRIPTION
Pixel Poo is a companion collection for the OG Fractal Shiddz, so we need to change twitter to the same account.