### PR TITLE
Update website and check 1111x inscriptions (not 1118)

### DIFF
--- a/collections/fractaltrexisalsoded/meta.json
+++ b/collections/fractaltrexisalsoded/meta.json
@@ -5,5 +5,5 @@
   "name": "fractaltrexisalsoded",
   "slug": "fractaltrexisalsoded",
   "twitter_link": "https://x.com/CryptoTrexNFT",
-  "website_link": "https://cryptotrex.anyside.com/"
+  "website_link": "https://cryptotrexnft.com/jumpy-trex"
 }


### PR DESCRIPTION
Hi Cloud 2 things:

1.) META - Kindly update Meta - The hosting service we use "anyside" didnt renew SSL, so it shows unsecured and well rather point to the trex game for now till we sort this out,

2.) INSCRIPTIONS COUNT
There are only 1111x inscriptions in our json. Ive downloaded the file from Unisat main branch and it also shows only 1111x inscriptions....... But for some reason market shows 1118x inscriptions?
[inscriptions.json](https://github.com/user-attachments/files/17269852/inscriptions.json)
