### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/collections/ColorHead/meta.json
+++ b/collections/ColorHead/meta.json
@@ -4,6 +4,6 @@
 "icon": "https://www.flickr.com/photos/201771291@N06/54118767286/in/album-72177720321723292",
 "name": "ColorHead",
 "slug": "ColorHead",
-"twitter_link": "https://twitter.com/must1f1h11",
+"twitter_link": "https://x.com/must1f1h11",
 "website_link": "https://must1f1h11.radius.art/"
 }

--- a/collections/bordz/meta.json
+++ b/collections/bordz/meta.json
@@ -3,7 +3,7 @@
     "icon": "https://i.ibb.co/NjmK6Gx/bordz-600kb-19.jpg",
     "name": "b-ordz",
     "slug": "bordz",
-    "twitter_link": "https://twitter.com/pic_ADA_sso",
+    "twitter_link": "https://x.com/pic_ADA_sso",
     "website_link": "https://bordz.neocities.org/"
 }
 

--- a/collections/domoducks-indelibly/meta.json
+++ b/collections/domoducks-indelibly/meta.json
@@ -4,6 +4,6 @@
 "icon": "https://live.staticflickr.com/65535/54001516635_d64f8c4965_o.gif",
 "name": "DomoDucks (Indelibly)",
 "slug": "domoducks-indelibly",
-"twitter_link": "https://twitter.com/DomoDucks",
+"twitter_link": "https://x.com/DomoDucks",
 "website_link": "https://domoducks.gitbook.io/domoducks/"
 }

--- a/collections/fracbots/meta.json
+++ b/collections/fracbots/meta.json
@@ -4,6 +4,6 @@
   "inscription_icon": "66f39390f5a34ea416c4522e30bda4b022d77ecb57babcae6fa6696b4498ed6di0",
   "name": "Fracbots",
   "slug": "fracbots",
-  "twitter_link": "https://twitter.com/fracbots",
+  "twitter_link": "https://x.com/fracbots",
   "website_link": ""
 }

--- a/collections/fractal_trees_mdv/meta.json
+++ b/collections/fractal_trees_mdv/meta.json
@@ -4,6 +4,6 @@
   "icon": "https://fractal.inscribenow.io/uploads/f2a7c079b0a86f096c31..gif",
   "name": "Fractal Trees 3D ~ MDV",
   "slug": "fractal_trees_mdv",
-  "twitter_link": "https://twitter.com/btc_substance",
+  "twitter_link": "https://x.com/btc_substance",
   "website_link": "https://btcsubstance.com"
 }

--- a/collections/fractal_wolves/meta.json
+++ b/collections/fractal_wolves/meta.json
@@ -4,6 +4,6 @@
     "icon": "https://fractal.inscribenow.io/uploads/8f8e9692b52e16a312fa..gif",
     "name": "Fractal Wolves",
     "slug": "fractal_wolves",
-    "twitter_link": "https://twitter.com/Fractal_wolves",
+    "twitter_link": "https://x.com/Fractal_wolves",
     "website_link": "https://chaoticwolves.xyz"
 }

--- a/collections/rainbowpunks/meta.json
+++ b/collections/rainbowpunks/meta.json
@@ -4,6 +4,6 @@
   "inscription_icon": "369d3153666a12d5d0ff85894c50e8b6f59d4f9aee93daaa0ab2eaa30621ec47i0",
   "name": "Rainbow Punks",
   "slug": "rainbowpunks",
-  "twitter_link": "https://twitter.com/RainbowPunksFB",
+  "twitter_link": "https://x.com/RainbowPunksFB",
   "website_link": "https://fractal.inscribenow.io/collections/a557b56d106f3c48"
 }

--- a/meta.json
+++ b/meta.json
@@ -4,6 +4,6 @@
 "icon": "https://live.staticflickr.com/65535/54001516635_d64f8c4965_o.gif",
 "name": "DomoDucks (Indelibly)",
 "slug": "domoducks-indelibly",
-"twitter_link": "https://twitter.com/DomoDucks",
+"twitter_link": "https://x.com/DomoDucks",
 "website_link": "https://domoducks.gitbook.io/domoducks/"
 }

--- a/tests/test_colllections.py
+++ b/tests/test_colllections.py
@@ -40,7 +40,7 @@ def test_meta():
         "supply": "100",
         "slug": "based-apes",
         "description": "",
-        "twitter_link": "https://twitter.com/BasedApes",
+        "twitter_link": "https://x.com/BasedApes",
         "discord_link": "https://discord.com/invite/ordinalswallet",
         "website_link": "",
     }


### PR DESCRIPTION
Updated the Twitter URL from https://twitter.com/ to https://x.com/ to reflect the platform's rebranding.